### PR TITLE
Fix code scanning alert no. 6: DOM text reinterpreted as HTML

### DIFF
--- a/addons/webinterface.default/themes/base/fonts/icomoon/demo-files/demo.js
+++ b/addons/webinterface.default/themes/base/fonts/icomoon/demo-files/demo.js
@@ -15,7 +15,11 @@ document.body.addEventListener("click", function(e) {
         testDrive = document.getElementById('testDrive'),
         testText = document.getElementById('testText');
     function updateTest() {
-        testDrive.innerHTML = testText.value || String.fromCharCode(160);
+        while (testDrive.firstChild) {
+            testDrive.removeChild(testDrive.firstChild);
+        }
+        var textNode = document.createTextNode(testText.value || String.fromCharCode(160));
+        testDrive.appendChild(textNode);
         if (window.icomoonLiga) {
             window.icomoonLiga(testDrive);
         }


### PR DESCRIPTION
Fixes [https://github.com/ewe360irl/xbmcewe/security/code-scanning/6](https://github.com/ewe360irl/xbmcewe/security/code-scanning/6)

To fix the problem, we need to ensure that any text assigned to `innerHTML` is properly escaped to prevent it from being interpreted as HTML. This can be achieved by using a text node or a library that handles HTML escaping.

The best way to fix this issue without changing existing functionality is to create a text node and assign the `testText.value` to it. This way, the text will be treated as plain text and not HTML.

We need to modify the code in the `addons/webinterface.default/themes/base/fonts/icomoon/demo-files/demo.js` file, specifically the `updateTest` function, to use a text node instead of directly assigning to `innerHTML`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
